### PR TITLE
fix nil check for LsSRv6SIDNLRI

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -803,17 +803,21 @@ func MarshalLsSRv6SIDNLRI(n *bgp.LsSrv6SIDNLRI) (*apb.Any, error) {
 	if err != nil {
 		return nil, err
 	}
-	sc, ok := n.ServiceChaining.(*bgp.LsTLVServiceChaining)
-	if !ok {
-		return nil, fmt.Errorf("invalid service chaining type")
+
+	var serviceChaining *api.LsServiceChaining
+	if sc, ok := n.ServiceChaining.(*bgp.LsTLVServiceChaining); ok && sc != nil {
+		serviceChaining, err = MarshalLsTLVServiceChaining(sc)
+		if err != nil {
+			return nil, err
+		}
 	}
-	serviceChaining, err := MarshalLsTLVServiceChaining(sc)
-	if err != nil {
-		return nil, err
-	}
-	opaqueMetadata, err := MarshalLsTLVOpaqueMetadata(n.OpaqueMetadata.(*bgp.LsTLVOpaqueMetadata))
-	if err != nil {
-		return nil, err
+
+	var opaqueMetadata *api.LsOpaqueMetadata
+	if om, ok := n.OpaqueMetadata.(*bgp.LsTLVOpaqueMetadata); ok && om != nil {
+		opaqueMetadata, err = MarshalLsTLVOpaqueMetadata(om)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	srv6sid := &api.LsSrv6SIDNLRI{
@@ -904,7 +908,11 @@ func UnmarshalLsLinkDescriptor(ld *api.LsLinkDescriptor) (*bgp.LsLinkDescriptor,
 func UnmarshalPrefixDescriptor(pd *api.LsPrefixDescriptor) (*bgp.LsPrefixDescriptor, error) {
 	ipReachability := []net.IPNet{}
 	for _, reach := range pd.IpReachability {
-		_, ipnet, _ := net.ParseCIDR(reach)
+		_, ipnet, err := net.ParseCIDR(reach)
+		if err != nil {
+			// Skipping invalid prefix
+			continue
+		}
 		ipReachability = append(ipReachability, *ipnet)
 	}
 
@@ -1891,14 +1899,20 @@ func UnmarshalNLRI(rf bgp.RouteFamily, an *apb.Any) (bgp.AddrPrefixInterface, er
 				return nil, err
 			}
 
-			scTLV, err := UnmarshalLsTLVServiceChaining(tp.ServiceChaining)
-			if err != nil {
-				return nil, err
+			var scTLV *bgp.LsTLVServiceChaining
+			if tp.ServiceChaining != nil {
+				scTLV, err = UnmarshalLsTLVServiceChaining(tp.ServiceChaining)
+				if err != nil {
+					return nil, err
+				}
 			}
 
-			omTLV, err := UnmarshalLsTLVOpaqueMetadata(tp.OpaqueMetadata)
-			if err != nil {
-				return nil, err
+			var omTLV *bgp.LsTLVOpaqueMetadata
+			if tp.OpaqueMetadata != nil {
+				omTLV, err = UnmarshalLsTLVOpaqueMetadata(tp.OpaqueMetadata)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			nlri = &bgp.LsAddrPrefix{

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -6095,19 +6095,23 @@ func (l *LsSrv6SIDNLRI) Serialize() ([]byte, error) {
 	}
 
 	if l.ServiceChaining != nil {
-		s, err = l.ServiceChaining.Serialize()
-		if err != nil {
-			return nil, err
+		if sc, ok := l.ServiceChaining.(*LsTLVServiceChaining); ok && sc != nil {
+			s, err = sc.Serialize()
+			if err != nil {
+				return nil, err
+			}
+			buf = append(buf, s...)
 		}
-		buf = append(buf, s...)
 	}
 
 	if l.OpaqueMetadata != nil {
-		s, err = l.OpaqueMetadata.Serialize()
-		if err != nil {
-			return nil, err
+		if om, ok := l.OpaqueMetadata.(*LsTLVOpaqueMetadata); ok && om != nil {
+			s, err = om.Serialize()
+			if err != nil {
+				return nil, err
+			}
+			buf = append(buf, s...)
 		}
-		buf = append(buf, s...)
 	}
 
 	return l.LsNLRI.Serialize(buf)


### PR DESCRIPTION
## 目的
BGP-LS Service Segment用のServiceChaining TLVとOpaqueMetadata TLVのnil checkを修正すること．

## 実装内容
- LsSrv6SIDNLRI構造体に含まれているServiceChainingとOpaqueMetadataはインターフェース型であるため，適切なnil判定をSerialize，MarshalLsSRv6SIDNLRI，UnmarshalNLRIに追加．
- IOS-XRv9kとの検証時に発生したPrefixDescriptorのParseCIDRに失敗するエラー処理をスキップする処理を追加．

## 注意点
- IOS-XRv9k - GoBGP(Pola PCE)の検証時にLsSRv6SIDNLRI以外のNLRIにも修正が必要であったため，一旦エラー処理をスキップすることで本題であるBGP-LS Service Segmentの検証を実施しました．なので，BGP-LS Service Segmentとは関係のないトポロジではエラーが発生するかもしれないです．